### PR TITLE
flake: add checks.benchmark and apps.benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ cabal bench
 ```
 
 This will write the benchmark report to `report.html`.
+
+### Benchmarking a commit
+
+To run benchmarks on a particular commit,
+
+```
+nix run github:Plutonomicon/pluton/<COMMIT-GOES-HERE>#benchmark
+```

--- a/flake.nix
+++ b/flake.nix
@@ -124,9 +124,15 @@
       in
       flake // {
         apps = {
+          benchmark = {
+            type = "app";
+            program = "${flake.packages."pluton:bench:perf"}/bin/perf";
+          };
           # Add more apps here ...
         };
-        checks = { };
+        checks = {
+          benchmark = pkgs.runCommand "benchmark" {} "${self.apps.${system}.benchmark.program} | tee $out";
+        };
         ciNix = inputs.flake-compat-ci.lib.recurseIntoFlakeWith {
           flake = self;
           systems = [ "x86_64-linux" ];


### PR DESCRIPTION
Adds a check that runs the benchmark from the result of the
`pluton:bench:perf` package that our Flake outputs. This can be built
like `nix build .#checks.x86_64-linux.benchmark` for example. It will
also be ran via `nix flake check`.

Alternatively, if you want to get the effects that are generated by the
benchmark such as `bench.csv`, `bench.json` and `bench.html` you can use 
`nix run`, like `nix run .#benchmark`. 

In the implementation, `checks.benchmark` follows `apps.benchmark.program`.
Ideally, anyone modifying this code should make all changes to the 
`apps.benchmark.program` before even attempting to modify the check. The 
check is only intended to run in CI.

#9 