### PR TITLE
Add Hercules-CI Flake support

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,0 +1,3 @@
+if builtins?getFlake
+then (builtins.getFlake (toString ./.)).ciNix
+else (import ./flake-compat.nix).defaultNix.ciNix

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,0 +1,9 @@
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+  flake-compat = builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+in
+import flake-compat { src = ./.; }

--- a/flake.lock
+++ b/flake.lock
@@ -82,6 +82,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-compat-ci": {
       "locked": {
         "lastModified": 1638753619,
@@ -452,6 +468,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-compat-ci": "flake-compat-ci",
         "flake-utils": "flake-utils",
         "haskell-nix": "haskell-nix",


### PR DESCRIPTION
The repo was improperly configured for Hercules-CI to use Flakes. This uses the [flake-compat-ci](https://github.com/hercules-ci/flake-compat-ci) stopgap to initialize support for Flakes now.